### PR TITLE
refactor: use mkFlake directly

### DIFF
--- a/config/basic/flake.nix
+++ b/config/basic/flake.nix
@@ -13,13 +13,10 @@
   };
 
   outputs = inputs:
-    let
-      lib = inputs.snowfall-lib.mkLib {
-        inherit inputs;
-        src = ./.;
-      };
-    in
-    lib.mkFlake {
+    inputs.snowfall-lib.mkFlake {
+      inherit inputs;
+      src = ./.;
+
       channels-config.allowUnfree = true;
       systems.modules = with inputs; [
         snowflake.nixosModules.snowflake


### PR DESCRIPTION
Hey @vlinkz, I saw you started including Snowfall Lib in the project. Super cool! I'm sure you're still playing around with it, but wanted to mention this just in case. Since it's pretty common to not need access to libraries within `flake.nix` itself, Snowfall Lib has a helper to build flake outputs directly. It cuts out a little extra code and keeps things tidy.

Feel free to ignore this PR, I just wanted to mention it in case it's useful :+1: 